### PR TITLE
[MEMO1.0-002] 設定内テーマ画面のラベルをテーマと表示するよう修正しました

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,7 +25,8 @@
         <activity
             android:name=".ui.edit.EditActivity"
             android:windowSoftInputMode="adjustResize" />
-        <activity android:name=".ui.theme.ThemeActivity" />
+        <activity android:name=".ui.theme.ThemeActivity"
+            android:label="@string/theme"/>
         <activity android:name=".ui.aboutapp.AboutAppActivity" />
         <activity
             android:name=".ui.search.SearchActivity"


### PR DESCRIPTION
### **問題の原因**

- AndroidManifest.xmlにてlabelが記述されていないため

### **対応内容**

- AndroidManifest.xmlにandroid:label="@string/theme"を追加

### **fixed file**

- AndroidManifest.xml

### **コミット前の動作確認**

- アプリを起動
- 設定ボタンをタップ
- テーマをタップ
- テーマ選択画面のラベルがテーマになっていること