### PR TITLE
[MEMO1.0-003]: テーマ設定画面のステータスバーの色を正しいものに修正

### DIFF
--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -15,11 +15,11 @@
     <color name="colorStatusBar1">#DC8D7B</color>// 220 141 123
     <color name="colorStatusBar2">#DE8EB3</color>// 222 142 179
     <color name="colorStatusBar3">#C79CE8</color>// 199 156 232
-    <color name="colorStatusBar4">#E4A469</color>// 48 79 193
+    <color name="colorStatusBar4">#304FC1</color>// 228 164 105
     <color name="colorStatusBar5">#92AAD6</color>// 146 170 214
     <color name="colorStatusBar6">#81AAA7</color>// 129 170 167
     <color name="colorStatusBar7">#6EA369</color>// 110 163 105
-    <color name="colorStatusBar8">#304FC1</color>// 228 164 105
+    <color name="colorStatusBar8">#E4A469</color>// 48 79 193
 
     <!-- HeaderBar Color -->
     <color name="colorHeaderBar1">#E9B6AA</color>// 233 182 170

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -15,11 +15,11 @@
     <color name="colorStatusBar1">#DC8D7B</color>// 220 141 123
     <color name="colorStatusBar2">#DE8EB3</color>// 222 142 179
     <color name="colorStatusBar3">#C79CE8</color>// 199 156 232
-    <color name="colorStatusBar4">#304FC1</color>// 228 164 105
+    <color name="colorStatusBar4">#304FC1</color>// 48 79 193　
     <color name="colorStatusBar5">#92AAD6</color>// 146 170 214
     <color name="colorStatusBar6">#81AAA7</color>// 129 170 167
     <color name="colorStatusBar7">#6EA369</color>// 110 163 105
-    <color name="colorStatusBar8">#E4A469</color>// 48 79 193
+    <color name="colorStatusBar8">#E4A469</color>// 228 164 105
 
     <!-- HeaderBar Color -->
     <color name="colorHeaderBar1">#E9B6AA</color>// 233 182 170


### PR DESCRIPTION
### **問題の原因**

- テーマ設定画面の右側上から２番目のステータスバーと右側上から４番目のステータスバーの色が入れ違っている

### **対応内容**

- 右側上から２番目のステータスバーの色を、正しい色（#304FC1)に表示するよう修正
- 右側上から４番目のステータスバーの色を、正しい色（#E4A469)に表示するよう修正

### **fixed file**

- value/colors.xml

### **コミット前の動作確認**

- アプリを起動
- 設定ボタンをタップ
- ツールをタップ
- 右側上から２番目のステータスバーの色を、正しい色（#304FC1)で表示されるか
- 右側上から４番目のステータスバーの色を、正しい色（#E4A469)で表示されるか