### PR TITLE
[MEMO1.0-006]: アプリ名が正しく表示されるよう修正

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,7 +9,7 @@
         android:name=".MyApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher_round"
-        android:label="@string/app_name"
+        android:label="@string/app_title"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.AppCompat.Light.NoActionBar.FullScreen">

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -15,11 +15,11 @@
     <color name="colorStatusBar1">#DC8D7B</color>// 220 141 123
     <color name="colorStatusBar2">#DE8EB3</color>// 222 142 179
     <color name="colorStatusBar3">#C79CE8</color>// 199 156 232
-    <color name="colorStatusBar4">#E4A469</color>// 48 79 193
+    <color name="colorStatusBar4">#304FC1</color>// 228 164 105
     <color name="colorStatusBar5">#92AAD6</color>// 146 170 214
     <color name="colorStatusBar6">#81AAA7</color>// 129 170 167
     <color name="colorStatusBar7">#6EA369</color>// 110 163 105
-    <color name="colorStatusBar8">#304FC1</color>// 228 164 105
+    <color name="colorStatusBar8">#E4A469</color>// 48 79 193
 
     <!-- HeaderBar Color -->
     <color name="colorHeaderBar1">#E9B6AA</color>// 233 182 170

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,6 @@
 <resources>
-    <string name="app_name">メモ帳</string>
+    <string name="app_name">メーモ</string>
+    <string name="app_title">メモ帳</string>
     <string name="navigation_drawer_open">Open navigation drawer</string>
     <string name="navigation_drawer_close">Close navigation drawer</string>
 


### PR DESCRIPTION
### **問題の原因**

- src\main\res\values\strings.xmlのapp_nameがメモ帳になっていた。

### **対応内容**

- src\main\res\values\strings.xmlの<string name="app_name">メモ帳</string>を
　<string name="app_name">メーモ</string>に修正
- src\main\res\values\strings.xmlに<string name="app_title">メモ帳</string>を追加
- AndroidManifest.xmlの対象の個所をapp_titleに変更

### **fixed file**

- src\main\res\values\strings.xml
- AndroidManifest.xml

### **コミット前の動作確認**

- ランチャーアイコン下のアプリ名がメーモになっていること
