### PR TITLE
[MEMO1.0-007]: メモが空の場合の表示が正しく表示されるよう修正。

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,7 +9,7 @@
         android:name=".MyApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher_round"
-        android:label="@string/app_name"
+        android:label="@string/app_title"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.AppCompat.Light.NoActionBar.FullScreen">

--- a/app/src/main/java/com/example/e01_memo/ui/main/MainFragment.java
+++ b/app/src/main/java/com/example/e01_memo/ui/main/MainFragment.java
@@ -225,7 +225,7 @@ public class MainFragment extends BaseFragment implements MainContract.MainView 
         recyclerView.setVisibility(View.GONE);
         emptyText.setVisibility(View.VISIBLE);
         if (MyApplication.selectNavigationItem != Constant.NavigationItem.DELETE) {
-            emptyText.setText("空です");
+            emptyText.setText("メモがありません。");
         }
     }
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -15,11 +15,11 @@
     <color name="colorStatusBar1">#DC8D7B</color>// 220 141 123
     <color name="colorStatusBar2">#DE8EB3</color>// 222 142 179
     <color name="colorStatusBar3">#C79CE8</color>// 199 156 232
-    <color name="colorStatusBar4">#E4A469</color>// 48 79 193
+    <color name="colorStatusBar4">#304FC1</color>// 228 164 105
     <color name="colorStatusBar5">#92AAD6</color>// 146 170 214
     <color name="colorStatusBar6">#81AAA7</color>// 129 170 167
     <color name="colorStatusBar7">#6EA369</color>// 110 163 105
-    <color name="colorStatusBar8">#304FC1</color>// 228 164 105
+    <color name="colorStatusBar8">#E4A469</color>// 48 79 193
 
     <!-- HeaderBar Color -->
     <color name="colorHeaderBar1">#E9B6AA</color>// 233 182 170

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,6 @@
 <resources>
-    <string name="app_name">メモ帳</string>
+    <string name="app_name">メーモ</string>
+    <string name="app_title">メモ帳</string>
     <string name="navigation_drawer_open">Open navigation drawer</string>
     <string name="navigation_drawer_close">Close navigation drawer</string>
 


### PR DESCRIPTION
### **問題の原因**

- app\src\main\java\com\example\e01_memo\ui\main\MainFragment.javaのL228に
「空です」と記述されていた。

### **対応内容**

- app\src\main\java\com\example\e01_memo\ui\main\MainFragment.javaのL228を
「メモがありません」に変更


### **fixed file**

- app\src\main\java\com\example\e01_memo\ui\main\MainFragment.java

### **コミット前の動作確認**

- アプリを起動
- メモがない場合「メモがありませんと表示されること」

