### PR TITLE
[MEMO1.0-007]: メモが空の場合の表示が正しくない。 修正

### DIFF
--- a/app/src/main/java/com/example/e01_memo/ui/main/MainFragment.java
+++ b/app/src/main/java/com/example/e01_memo/ui/main/MainFragment.java
@@ -225,7 +225,7 @@ public class MainFragment extends BaseFragment implements MainContract.MainView 
         recyclerView.setVisibility(View.GONE);
         emptyText.setVisibility(View.VISIBLE);
         if (MyApplication.selectNavigationItem != Constant.NavigationItem.DELETE) {
-            emptyText.setText("メモがありません");
+            emptyText.setText("メモがありません。");
         }
     }
 

--- a/app/src/main/java/com/example/e01_memo/ui/main/MainFragment.java
+++ b/app/src/main/java/com/example/e01_memo/ui/main/MainFragment.java
@@ -225,7 +225,7 @@ public class MainFragment extends BaseFragment implements MainContract.MainView 
         recyclerView.setVisibility(View.GONE);
         emptyText.setVisibility(View.VISIBLE);
         if (MyApplication.selectNavigationItem != Constant.NavigationItem.DELETE) {
-            emptyText.setText("空です");
+            emptyText.setText("メモがありません");
         }
     }
 

--- a/app/src/main/java/com/example/e01_memo/ui/main/MainFragment.java
+++ b/app/src/main/java/com/example/e01_memo/ui/main/MainFragment.java
@@ -225,7 +225,7 @@ public class MainFragment extends BaseFragment implements MainContract.MainView 
         recyclerView.setVisibility(View.GONE);
         emptyText.setVisibility(View.VISIBLE);
         if (MyApplication.selectNavigationItem != Constant.NavigationItem.DELETE) {
-            emptyText.setText("メモがありません。");
+            emptyText.setText(R.string.not_memo);
         }
     }
 


### PR DESCRIPTION
### **問題の原因**

- 「空です」と表示される処理になっていた。

### **対応内容**

- 「空です」をstrings.xmlに定義された「メモがありません。」を使用するよう変更

### **fixed file**

- MainFragment

### **コミット前の動作確認**

- 実行前の状態：メモを空にしておく。
- アプリを起動する。
- 画面中央に「メモがありません」と表示される。