### PR TITLE
[MEMO1.0-006]: アプリ名が正しくない。修正

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">メモ帳</string>
+    <string name="app_name">メーモ</string>
     <string name="navigation_drawer_open">Open navigation drawer</string>
     <string name="navigation_drawer_close">Close navigation drawer</string>
 


### PR DESCRIPTION
### **問題の原因**

- src\main\res\values\strings.xmlのapp_nameがメモ帳になっていた。

### **対応内容**

- src\main\res\values\strings.xmlの<string name="app_name">メモ帳</string>を
　<string name="app_name">メーモ</string>に修正

### **fixed file**

- src\main\res\values\strings.xml

### **コミット前の動作確認**

- ランチャーアイコン下のアプリ名がメーモになっていること
