### PR TITLE
[MEMO1.0-005]: メモに文字を入力できない。修正

### DIFF
--- a/app/src/main/res/layout/fragment_edit.xml
+++ b/app/src/main/res/layout/fragment_edit.xml
@@ -27,7 +27,7 @@
         android:gravity="top"
         android:paddingTop="16dp"
         android:paddingStart="16dp"
-        android:textSize="16sp" />
+        android:textSize="16sp" ><requestFocus/></EditText>
 
     <LinearLayout
         android:id="@+id/editBottomBar"

--- a/app/src/main/res/layout/fragment_edit.xml
+++ b/app/src/main/res/layout/fragment_edit.xml
@@ -3,47 +3,50 @@
     android:id="@+id/rootView"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:fitsSystemWindows="true"
-    android:background="?android:attr/colorBackground">
+    android:background="?android:attr/colorBackground"
+    android:fitsSystemWindows="true">
 
     <TextView
         android:id="@+id/textView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_marginTop="?android:attr/actionBarSize"
+        android:background="#FFFFFF"
         android:gravity="top"
-        android:paddingTop="16dp"
         android:paddingStart="16dp"
-        android:textSize="14sp"
+        android:paddingTop="16dp"
         android:textColor="@android:color/black"
-        android:background="#FFFFFF"/>
+        android:textSize="14sp" />
 
     <EditText
         android:id="@+id/editText"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_weight="1"
-        android:hint="メモ"
         android:gravity="top"
-        android:paddingTop="16dp"
+        android:hint="メモ"
         android:paddingStart="16dp"
-        android:textSize="16sp" ><requestFocus/></EditText>
+        android:paddingTop="16dp"
+        android:textSize="16sp">
+
+        <requestFocus />
+    </EditText>
 
     <LinearLayout
         android:id="@+id/editBottomBar"
         android:layout_width="match_parent"
         android:layout_height="48dp"
-        android:orientation="horizontal"
         android:layout_gravity="bottom"
         android:background="?attr/colorSecondary"
-        android:gravity="center_vertical">
+        android:gravity="center_vertical"
+        android:orientation="horizontal">
 
         <ImageView
             android:id="@+id/favoriteImg"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:src="@mipmap/ic_favorite_off"
-            android:paddingStart="16dp"/>
+            android:paddingStart="16dp"
+            android:src="@mipmap/ic_favorite_off" />
 
         <TextView
             android:id="@+id/mojiText"
@@ -52,9 +55,9 @@
             android:layout_weight="1"
             android:gravity="end"
             android:paddingEnd="20dp"
-            android:textSize="20sp"
+            android:text="0"
             android:textColor="@color/colorGray"
-            android:text="0"/>
+            android:textSize="20sp" />
 
     </LinearLayout>
 


### PR DESCRIPTION
### **問題の原因**

- 新規メモ画面へ遷移後、フォーカスが表示されていなかった

### **対応内容**

- 新規メモ作成画面に遷移した際、自動でフォーカスが表示されるよう処理を追加

### **fixed file**

-  fragment_edit.xml

### **コミット前の動作確認**

- アプリを起動
- 新規メモ作成ボタンをタップ
- フォーカスが自動で表示され文字入力ができること