### PR TITLE
[MEMO1.0-010]: バージョン番号が間違っている。修正

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 28
 
     // app versioning
-    def versionMajor = 0
+    def versionMajor = 1
     def versionMinor = 0
     def versionPatch = 0
     def versionBuild = 0


### PR DESCRIPTION
### **問題の原因**

- バージョンが0.0.0と表示されていた。

### **対応内容**

- バージョンが1.0.0と表示されるよう変更

### **fixed file**

- build.gradle

### **コミット前の動作確認**

- アプリを起動
- 右上にある設定ボタンをタップ
- 「このアプリについて」をタップ
- バージョンが1.0.0になっていること
