### PR TITLE
[MEMO1.0-013]: 文字サイズ「小」に設定すると文字が小さくなりすぎる。修正

### DIFF
--- a/app/src/main/java/com/example/e01_memo/util/SharedPreferencesUtil.java
+++ b/app/src/main/java/com/example/e01_memo/util/SharedPreferencesUtil.java
@@ -34,7 +34,7 @@ public class SharedPreferencesUtil {
     }
 
     public enum MojiSizeSetting {
-        MojiSmall(R.string.small, 8), MojiDefault(R.string.defaultStr, 16), MojiBig(R.string.big, 20);
+        MojiSmall(R.string.small, 12), MojiDefault(R.string.defaultStr, 16), MojiBig(R.string.big, 20);
         int mojiSize;
         int mojiNameResId;
         MojiSizeSetting(int nameResId, int size) {


### PR DESCRIPTION
### **問題の原因**

- 文字のサイズが「小」を選択した場合、8dpになっていた。

### **対応内容**

- SharedPreferencesUtil.java にて文字サイズを8dpから12dpに変更

### **fixed file**

- SharedPreferencesUtil.java 

### **コミット前の動作確認**

- 設定画面に遷移
- 文字サイズをタップ
- 「小」を選択
- 新規作成画面にて文字を入力
-  文字のサイズを確認すること
